### PR TITLE
Adds missing Events

### DIFF
--- a/Assets.php
+++ b/Assets.php
@@ -6,7 +6,7 @@
  * @license   https://www.humhub.com/licences
  */
 
-namespace humhub\modules\music_player;
+namespace humhub\modules\musicplayer;
 
 use yii\web\AssetBundle;
 

--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace humhub\modules\music_player;
+namespace humhub\modules\musicplayer;
 
 use humhub\models\Setting;
 use Yii;
@@ -8,10 +8,10 @@ use yii\helpers\Url;
 
 class Module extends \humhub\components\Module {
 
-  const NAME = 'music_player';
+  const NAME = 'musicplayer';
 
   /**
-   * On build of the dashboard sidebar widget, add the music_player widget if module is enabled.
+   * On build of the dashboard sidebar widget, add the music player widget if module is enabled.
    *
    * @param type $event
    */
@@ -29,7 +29,7 @@ class Module extends \humhub\components\Module {
   }
 
   public function getConfigUrl() {
-    return Url::to(['/music_player/config/config']);
+    return Url::to(['/musicplayer/config/config']);
   }
 
   /**

--- a/config.php
+++ b/config.php
@@ -4,7 +4,10 @@ use humhub\modules\dashboard\widgets\Sidebar;
 
 return [
   'id'        => 'music_player',
-  'class'     => 'humhub\modules\music_player\Module',
-  'namespace' => 'humhub\modules\music_player',
+  'class'     => 'humhub\modules\musicplayer\Module',
+  'namespace' => 'humhub\modules\musicplayer',
+    'events' => [
+        ['class' => Sidebar::className(), 'event' => Sidebar::EVENT_INIT, 'callback' => ['humhub\modules\musicplayer\Module', 'onSidebarInit']],
+    ],
 ];
 ?>

--- a/widgets/Sidebar.php
+++ b/widgets/Sidebar.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace humhub\modules\music_player\widgets;
+namespace humhub\modules\musicplayer\widgets;
 
-use humhub\modules\music_player\models\MusicPlayer;
+use humhub\modules\musicplayer\models\MusicPlayer;
 
 class Sidebar extends \humhub\components\Widget {
 

--- a/widgets/views/sidebar.php
+++ b/widgets/views/sidebar.php
@@ -3,11 +3,11 @@
 humhub\modules\music_player\Assets::register($this);
 
   <!-- Display panel menu widget -->
-  <?php humhub\widgets\PanelMenu::widget(['id' => 'music_player-panel']); ?>
+  <?php humhub\widgets\PanelMenu::widget(['id' => 'musicplayer-panel']); ?>
 
   <div class="panel-heading">
     <?php echo Yii::t(
-      'music_playersModule.base',
+      'musicplayerModule.base',
       '<strong>Music</strong> Player'
     ); ?>
   </div>


### PR DESCRIPTION
I'm not sure about using `use humhub\modules\dashboard\widgets\Sidebar;` over `namespace humhub\modules\musicplayer;` this still should be looked into, also an Events.php should be created to handle events. But if you're wanting to avoid using an Events.php maybe looking into this [module](https://github.com/humhub/humhub-modules-mostactiveusers) could help slightly? All in all I liked how the [Humhub Basic Chat](https://github.com/petersmithca/humhub-basic-chat) was setup with events handlers. :smiley:
